### PR TITLE
Table creature_template missing script names

### DIFF
--- a/World/Updates/Rel20/20000_08_Missing_script_names_added_to_creature_template_table.sql
+++ b/World/Updates/Rel20/20000_08_Missing_script_names_added_to_creature_template_table.sql
@@ -1,0 +1,115 @@
+-- --------------------------------------------------------------------------------
+-- This is an attempt to create a full transactional update
+-- --------------------------------------------------------------------------------
+DROP PROCEDURE IF EXISTS `update_mangos`; 
+
+DELIMITER $$
+
+CREATE DEFINER=`root`@`localhost` PROCEDURE `update_mangos`()
+BEGIN
+    DECLARE bRollback BOOL  DEFAULT FALSE ;
+    DECLARE CONTINUE HANDLER FOR SQLEXCEPTION SET `bRollback` = TRUE;
+
+  SET @cOldRev = 'required_20000_07_Nonexistent_Script_Names_Removed';
+
+  -- Set the new revision string
+  SET @cNewRev = 'required_20000_08_Missing_script_names_added_to_creature_template_table';
+
+  -- Set thisRevision to the column name of db_version in the currently selected database
+  SET @cThisRev := ((SELECT column_name FROM information_schema.`COLUMNS` WHERE table_name='db_version' AND table_schema=(SELECT DATABASE() AS thisDB FROM DUAL) AND column_name LIKE 'required%'));
+
+ 
+  -- Only Proceed if the old values match
+  IF @cThisRev = @cOldRev THEN
+    -- Make this all a single transaction
+    START TRANSACTION;
+
+    -- Apply the Version Change from Old Version to New Version
+    SET @query = CONCAT('ALTER TABLE db_version CHANGE COLUMN ',@cOldRev, ' ' ,@cNewRev,' bit;');
+    PREPARE stmt1 FROM @query;
+    EXECUTE stmt1;
+    DEALLOCATE PREPARE stmt1;
+    -- The Above block is required for making table changes
+
+    -- -- -- -- Normal Update / Insert / Delete statements will go here  -- -- -- -- --
+
+    -- These delete script names from the creature_template table due to the scripts no longer existing (AI now dealt with by the creature_ai_scripts table)
+    
+    -- Shade of Taerar
+    -- script boss_shade_of_taerar
+    UPDATE creature_template SET ScriptName='' WHERE Entry='15302';
+
+    -- Demented Druid Spirit
+    -- script mob_dementeddruids
+    UPDATE creature_template SET ScriptName='' WHERE Entry='15260';
+    
+    -- Ogres in Blade's Edge Mountains (at this time the ogres are not scripted at all, but there is a post in the tracker for this issue)
+    -- script mobs_bladespire_ogre
+    UPDATE creature_template SET ScriptName='' WHERE Entry='19998';
+    UPDATE creature_template SET ScriptName='' WHERE Entry='20334';
+    UPDATE creature_template SET ScriptName='' WHERE Entry='21296';
+    UPDATE creature_template SET ScriptName='' WHERE Entry='21975';
+    
+    -- Mount vendors
+    -- script npc_mount_vendor
+    UPDATE creature_template SET ScriptName='' WHERE Entry='384';
+    UPDATE creature_template SET ScriptName='' WHERE Entry='1261';
+    UPDATE creature_template SET ScriptName='' WHERE Entry='1460';
+    UPDATE creature_template SET ScriptName='' WHERE Entry='2357';
+    UPDATE creature_template SET ScriptName='' WHERE Entry='3362';
+    UPDATE creature_template SET ScriptName='' WHERE Entry='3685';
+    UPDATE creature_template SET ScriptName='' WHERE Entry='4730';
+    UPDATE creature_template SET ScriptName='' WHERE Entry='4731';
+    UPDATE creature_template SET ScriptName='' WHERE Entry='4885';
+    UPDATE creature_template SET ScriptName='' WHERE Entry='7952';
+    UPDATE creature_template SET ScriptName='' WHERE Entry='7955';
+    UPDATE creature_template SET ScriptName='' WHERE Entry='16264';
+    UPDATE creature_template SET ScriptName='' WHERE Entry='17584';
+    
+    -- script npc_prof_alchemy
+    UPDATE creature_template SET ScriptName='' WHERE Entry='17909';
+    UPDATE creature_template SET ScriptName='' WHERE Entry='19052';
+    UPDATE creature_template SET ScriptName='' WHERE Entry='22427';
+
+    -- script npc_sayge
+    UPDATE creature_template SET ScriptName='' WHERE Entry='14822';
+    
+    -- script npc_sergeant_bly
+    UPDATE creature_template SET ScriptName='' WHERE Entry='7604';
+    
+    -- this guy also is missing a script (same as for the ogres), not even in creature_ai_scripts, and has had a thread made in the tracker for this
+    -- script npc_weegli_blastfuse
+    UPDATE creature_template SET ScriptName='' WHERE Entry='7607';
+    
+    -- Possibly missing scripts for the Druid flight form quest?
+    -- script go_shrine_of_the_birds
+    UPDATE gameobject_template SET ScriptName='' WHERE entry='185547';
+    UPDATE gameobject_template SET ScriptName='' WHERE entry='185551';
+    UPDATE gameobject_template SET ScriptName='' WHERE entry='185553';
+       
+    -- The script name was changed for this one, from npc_magher_captive to npc_nagrand_captive
+    UPDATE creature_template SET ScriptName='npc_nagrand_captive' WHERE Entry='18210';
+    
+    -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+    
+    -- If we get here ok, commit the changes
+    IF bRollback = TRUE THEN
+      ROLLBACK;
+      SELECT '* UPDATE FAILED *' AS 'Status',@cThisRev AS 'DB is on Version';
+    ELSE
+      COMMIT;
+      SELECT '* UPDATE COMPLETE *' AS 'Status',@cNewRev AS 'DB is now on Version';
+    END IF;
+  ELSE
+    SELECT '* UPDATE SKIPPED *' AS 'Status',@cOldRev AS 'Required Version',@cThisRev AS 'Found Version';
+  END IF;
+
+END $$
+
+DELIMITER ;
+
+-- Execute the procedure
+CALL update_mangos();
+
+-- Drop the procedure
+DROP PROCEDURE IF EXISTS `update_mangos`;

--- a/World/Updates/Rel20/20000_09_Last_of_the_ScriptDev2_errors_log_fixes.sql
+++ b/World/Updates/Rel20/20000_09_Last_of_the_ScriptDev2_errors_log_fixes.sql
@@ -1,0 +1,91 @@
+-- --------------------------------------------------------------------------------
+-- This is an attempt to create a full transactional update
+-- --------------------------------------------------------------------------------
+DROP PROCEDURE IF EXISTS `update_mangos`; 
+
+DELIMITER $$
+
+CREATE DEFINER=`root`@`localhost` PROCEDURE `update_mangos`()
+BEGIN
+    DECLARE bRollback BOOL  DEFAULT FALSE ;
+    DECLARE CONTINUE HANDLER FOR SQLEXCEPTION SET `bRollback` = TRUE;
+
+  SET @cOldRev = 'required_20000_08_Missing_script_names_added_to_creature_template_table';
+
+  -- Set the new revision string
+  SET @cNewRev = 'required_20000_09_Last_of_the_ScriptDev2_errors_log_fixes';
+
+  -- Set thisRevision to the column name of db_version in the currently selected database
+  SET @cThisRev := ((SELECT column_name FROM information_schema.`COLUMNS` WHERE table_name='db_version' AND table_schema=(SELECT DATABASE() AS thisDB FROM DUAL) AND column_name LIKE 'required%'));
+
+ 
+  -- Only Proceed if the old values match
+  IF @cThisRev = @cOldRev THEN
+    -- Make this all a single transaction
+    START TRANSACTION;
+
+    -- Apply the Version Change from Old Version to New Version
+    SET @query = CONCAT('ALTER TABLE db_version CHANGE COLUMN ',@cOldRev, ' ' ,@cNewRev,' bit;');
+    PREPARE stmt1 FROM @query;
+    EXECUTE stmt1;
+    DEALLOCATE PREPARE stmt1;
+    -- The Above block is required for making table changes
+
+    -- -- -- -- Normal Update / Insert / Delete statements will go here  -- -- -- -- --
+    
+    -- go_table_theka (Zero and One!!!!!)
+    UPDATE creature_template SET ScriptName='go_table_theka' WHERE Entry='7272';
+
+    -- boss_tethyr
+    UPDATE creature_template SET ScriptName='boss_tethyr' WHERE Entry=23899;
+
+    -- npc_piznik
+    UPDATE creature_template SET ScriptName='npc_piznik' WHERE Entry=4276;
+
+    -- npc_anchorite_barada
+    UPDATE creature_template SET ScriptName='npc_anchorite_barada' WHERE Entry=22431;
+
+    -- ncp_colonel_jules
+    UPDATE creature_template SET ScriptName='npc_colonel_jules' WHERE Entry='22432';
+
+    -- npc_rethhedron
+    UPDATE creature_template SET ScriptName='npc_rethhedron' WHERE Entry='23416';
+
+    -- npc_drijya
+    UPDATE creature_template SET ScriptName='npc_drijya' WHERE Entry='20281';
+
+    -- npc_cenarion_sparrowhawk
+    UPDATE creature_template SET ScriptName='npc_cenarion_sparrowhawk' WHERE Entry='22972';
+
+    -- npc_skyguard_prisoner
+    UPDATE creature_template SET ScriptName='npc_skyguard_prisoner' WHERE Entry='23383';
+
+    -- npc_fhwoor
+    UPDATE creature_template SET ScriptName='npc_fhwoor' WHERE Entry='17877';
+    
+    -- boss_head_of_horseman (yes, his head is an NPC/creature!)
+    UPDATE creature_template SET ScriptName='boss_head_of_horseman' WHERE Entry='23775';
+    
+    -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+    
+    -- If we get here ok, commit the changes
+    IF bRollback = TRUE THEN
+      ROLLBACK;
+      SELECT '* UPDATE FAILED *' AS 'Status',@cThisRev AS 'DB is on Version';
+    ELSE
+      COMMIT;
+      SELECT '* UPDATE COMPLETE *' AS 'Status',@cNewRev AS 'DB is now on Version';
+    END IF;
+  ELSE
+    SELECT '* UPDATE SKIPPED *' AS 'Status',@cOldRev AS 'Required Version',@cThisRev AS 'Found Version';
+  END IF;
+
+END $$
+
+DELIMITER ;
+
+-- Execute the procedure
+CALL update_mangos();
+
+-- Drop the procedure
+DROP PROCEDURE IF EXISTS `update_mangos`;

--- a/World/Updates/Rel20/20000_10_Bladespire_Ogres_creature_ai_scripts_added.sql
+++ b/World/Updates/Rel20/20000_10_Bladespire_Ogres_creature_ai_scripts_added.sql
@@ -1,0 +1,97 @@
+-- --------------------------------------------------------------------------------
+-- This is an attempt to create a full transactional update
+-- --------------------------------------------------------------------------------
+DROP PROCEDURE IF EXISTS `update_mangos`; 
+
+DELIMITER $$
+
+CREATE DEFINER=`root`@`localhost` PROCEDURE `update_mangos`()
+BEGIN
+    DECLARE bRollback BOOL  DEFAULT FALSE ;
+    DECLARE CONTINUE HANDLER FOR SQLEXCEPTION SET `bRollback` = TRUE;
+
+  SET @cOldRev = 'required_20000_09_Last_of_the_ScriptDev2_errors_log_fixes';
+
+  -- Set the new revision string
+  SET @cNewRev = 'required_20000_10_Bladespire_Ogres_creature_ai_scripts_added';
+
+  -- Set thisRevision to the column name of db_version in the currently selected database
+  SET @cThisRev := ((SELECT column_name FROM information_schema.`COLUMNS` WHERE table_name='db_version' AND table_schema=(SELECT DATABASE() AS thisDB FROM DUAL) AND column_name LIKE 'required%'));
+
+ 
+  -- Only Proceed if the old values match
+  IF @cThisRev = @cOldRev THEN
+    -- Make this all a single transaction
+    START TRANSACTION;
+
+    -- Apply the Version Change from Old Version to New Version
+    SET @query = CONCAT('ALTER TABLE db_version CHANGE COLUMN ',@cOldRev, ' ' ,@cNewRev,' bit;');
+    PREPARE stmt1 FROM @query;
+    EXECUTE stmt1;
+    DEALLOCATE PREPARE stmt1;
+    -- The Above block is required for making table changes
+
+    -- -- -- -- Normal Update / Insert / Delete statements will go here  -- -- -- -- --
+    
+    -- Bladespire Shaman: Entry: 19998
+    -- http://www.wowhead.com/npc=19998/bla...aman#abilities
+    -- enable script
+    UPDATE creature_template SET AIName='EventAI' WHERE Entry='19998';
+    -- add new script(s)
+    DELETE FROM creature_ai_scripts WHERE creature_id = 19998;
+    INSERT INTO creature_ai_scripts (`id`, `creature_id`, `event_type`, `event_inverse_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action1_type`, `action1_param1`, `action1_param2`, `action1_param3`, `action2_type`, `action2_param1`, `action2_param2`, `action2_param3`, `action3_type`, `action3_param1`, `action3_param2`, `action3_param3`, `comment`) VALUES ('1999801', '19998', '1', '0', '100', '1', '500', '800', '600000', '600000', '11', '35240', '0', '1', '0', '0', '0', '0', '0', '0', '0', '0', 'Bladespire Shamen - Cast Bloodmaul Intoxication');
+    INSERT INTO creature_ai_scripts (`id`, `creature_id`, `event_type`, `event_inverse_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action1_type`, `action1_param1`, `action1_param2`, `action1_param3`, `action2_type`, `action2_param1`, `action2_param2`, `action2_param3`, `action3_type`, `action3_param1`, `action3_param2`, `action3_param3`, `comment`) VALUES ('1999802', '19998', '0', '0', '100', '1', '4000', '8000', '30000', '45000', '11', '32062', '0', '1', '0', '0', '0', '0', '0', '0', '0', '0', 'Bladespire Shamen - Cast Fire Nova Totem');
+    INSERT INTO creature_ai_scripts (`id`, `creature_id`, `event_type`, `event_inverse_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action1_type`, `action1_param1`, `action1_param2`, `action1_param3`, `action2_type`, `action2_param1`, `action2_param2`, `action2_param3`, `action3_type`, `action3_param1`, `action3_param2`, `action3_param3`, `comment`) VALUES ('1999804', '19998', '9', '13', '100', '1', '0', '40', '2400', '3800', '11', '26098', '1', '0', '0', '0', '0', '0', '0', '0', '0', '0', 'Bladespire Shamen - Cast Lightning Bolt (Phase 1)');
+    INSERT INTO creature_ai_scripts (`id`, `creature_id`, `event_type`, `event_inverse_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action1_type`, `action1_param1`, `action1_param2`, `action1_param3`, `action2_type`, `action2_param1`, `action2_param2`, `action2_param3`, `action3_type`, `action3_param1`, `action3_param2`, `action3_param3`, `comment`) VALUES ('1999805', '19998', '1', '0', '100', '1', '1000', '1000', '600000', '600000', '11', '12550', '0', '1', '0', '0', '0', '0', '0', '0', '0', '0', 'Bladespire Shamen - Cast Lightning Shield on Aggro');
+
+    -- Bladespire Cook: Entry: 20334
+    -- http://www.wowhead.com/npc=20334#abilities
+    -- enable script
+    UPDATE creature_template SET AIName='EventAI' WHERE Entry='20334';
+    -- add new script(s)
+    DELETE FROM creature_ai_scripts WHERE creature_id = 20334;
+    INSERT INTO creature_ai_scripts (`id`, `creature_id`, `event_type`, `event_inverse_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action1_type`, `action1_param1`, `action1_param2`, `action1_param3`, `action2_type`, `action2_param1`, `action2_param2`, `action2_param3`, `action3_type`, `action3_param1`, `action3_param2`, `action3_param3`, `comment`) VALUES ('2033401', '20334', '1', '0', '100', '1', '500', '800', '600000', '600000', '11', '35240', '0', '1', '0', '0', '0', '0', '0', '0', '0', '0', 'Bladespire Cook - Cast Bloodmaul Intoxication');
+    INSERT INTO creature_ai_scripts (`id`, `creature_id`, `event_type`, `event_inverse_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action1_type`, `action1_param1`, `action1_param2`, `action1_param3`, `action2_type`, `action2_param1`, `action2_param2`, `action2_param3`, `action3_type`, `action3_param1`, `action3_param2`, `action3_param3`, `comment`) VALUES ('2033402', '20334', '0', '0', '100', '1', '2100', '6100', '14100', '20100', '11', '37597', '1', '0', '0', '0', '0', '0', '0', '0', '0', '0', 'Bladespire Cook - Cast Meat Slap');
+    INSERT INTO `mangosOne`.`creature_ai_scripts` (`id`, `creature_id`, `event_type`, `event_inverse_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action1_type`, `action1_param1`, `action1_param2`, `action1_param3`, `action2_type`, `action2_param1`, `action2_param2`, `action2_param3`, `action3_type`, `action3_param1`, `action3_param2`, `action3_param3`, `comment`) VALUES ('2033403', '20334', '0', '0', '100', '1', '1000', '5000', '40000', '45000', '11', '37596', '1', '0', '0', '0', '0', '0', '0', '0', '0', '0', 'Bladespire Cook - Cast Tenderize');
+
+    -- Bladespire Champion: Entry: 21296
+    -- http://www.wowhead.com/npc=21296#abilities
+    -- enable script
+    UPDATE creature_template SET AIName='EventAI' WHERE Entry='21296';
+    -- add new script(s)
+    DELETE FROM creature_ai_scripts WHERE creature_id = 21296;
+    INSERT INTO creature_ai_scripts (`id`, `creature_id`, `event_type`, `event_inverse_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action1_type`, `action1_param1`, `action1_param2`, `action1_param3`, `action2_type`, `action2_param1`, `action2_param2`, `action2_param3`, `action3_type`, `action3_param1`, `action3_param2`, `action3_param3`, `comment`) VALUES ('2129601', '21296', '1', '0', '100', '1', '500', '800', '600000', '600000', '11', '35240', '0', '1', '0', '0', '0', '0', '0', '0', '0', '0', 'Bladespire Champion - Cast Bloodmaul Intoxication');
+    INSERT INTO creature_ai_scripts (`id`, `creature_id`, `event_type`, `event_inverse_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action1_type`, `action1_param1`, `action1_param2`, `action1_param3`, `action2_type`, `action2_param1`, `action2_param2`, `action2_param3`, `action3_type`, `action3_param1`, `action3_param2`, `action3_param3`, `comment`) VALUES ('2129602', '21296', '4', '0', '15', '0', '0', '0', '0', '0', '11', '37777', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', 'Bladespire Champion - Cast Mighty Charge');
+    INSERT INTO creature_ai_scripts (`id`, `creature_id`, `event_type`, `event_inverse_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action1_type`, `action1_param1`, `action1_param2`, `action1_param3`, `action2_type`, `action2_param1`, `action2_param2`, `action2_param3`, `action3_type`, `action3_param1`, `action3_param2`, `action3_param3`, `comment`) VALUES ('2129603', '21296', '9', '0', '100', '1', '0', '8', '16000', '21000', '11', '8078', '0', '1', '0', '0', '0', '0', '0', '0', '0', '0', 'Bladespire Champion - Cast Thunderclap');
+
+    -- Bladespire Sober Defender: Entry: 21975
+    -- http://www.wowhead.com/npc=21975#abilities
+    -- enable script
+    UPDATE creature_template SET AIName='EventAI' WHERE Entry='21975';
+    -- add new script(s)
+    DELETE FROM creature_ai_scripts WHERE creature_id = 21975;
+    INSERT INTO creature_ai_scripts (`id`, `creature_id`, `event_type`, `event_inverse_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action1_type`, `action1_param1`, `action1_param2`, `action1_param3`, `action2_type`, `action2_param1`, `action2_param2`, `action2_param3`, `action3_type`, `action3_param1`, `action3_param2`, `action3_param3`, `comment`) VALUES ('2197501', '21975', '9', '0', '100', '1', '0', '5', '8000', '12000', '11', '15496', '1', '0', '0', '0', '0', '0', '0', '0', '0', '0', 'Bladespire Sober Defender - Cast Cleave');
+        
+    -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+    
+    -- If we get here ok, commit the changes
+    IF bRollback = TRUE THEN
+      ROLLBACK;
+      SELECT '* UPDATE FAILED *' AS 'Status',@cThisRev AS 'DB is on Version';
+    ELSE
+      COMMIT;
+      SELECT '* UPDATE COMPLETE *' AS 'Status',@cNewRev AS 'DB is now on Version';
+    END IF;
+  ELSE
+    SELECT '* UPDATE SKIPPED *' AS 'Status',@cOldRev AS 'Required Version',@cThisRev AS 'Found Version';
+  END IF;
+
+END $$
+
+DELIMITER ;
+
+-- Execute the procedure
+CALL update_mangos();
+
+-- Drop the procedure
+DROP PROCEDURE IF EXISTS `update_mangos`;


### PR DESCRIPTION
From the scriptdev2_errors.log file; this script fixes the remaining
errors/warnings (at this date).

The script names reported in the log file, were found to be missing from
the creature_template table.
